### PR TITLE
Standalone console tool to diagnose wireless connection issues

### DIFF
--- a/bin/kano-test-wifi
+++ b/bin/kano-test-wifi
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+
+'''
+kano-test-wiki - Diagnoses Kano Wireless Issues
+
+Usage:
+  kano-test-wifi test-device
+  kano-test-wifi test-signal <ssid>
+  kano-test-wifi test-connection <ssid> [--passphrase=<secret>]
+  kano-test-wifi test-all <ssid>  [--passphrase=<secret>]
+
+'''
+
+from docopt import docopt
+
+import os
+import sys
+import time
+import re
+
+# This embed configuration file is a replica of kano-toolset
+test_wpa_conf='''
+network={
+        ssid="%s"
+        psk="%s"
+
+          scan_ssid=1
+          key_mgmt=WPA-EAP WPA-PSK IEEE8021X NONE
+          pairwise=CCMP TKIP
+         }
+         ctrl_interface=/var/run/wpa_supplicant
+'''
+
+
+
+def test_device(wlan='wlan0'):
+    '''
+    Tests that the wireless device and driver are okay
+    '''
+    print 'TEST DEVICE'
+    passed=False
+    try:
+        iwdevinfo=os.popen('iw dev wlan0 info').read()
+        assert ('ifindex' in iwdevinfo)
+        assert ('wdev' in iwdevinfo)
+        assert ('addr' in iwdevinfo)
+        print iwdevinfo
+        print 'PASSED'
+        passed=True
+    except:
+        print 'FAILED 1 - Could not detect the wireless device'
+
+    return passed
+
+
+def test_signal(ssid):
+    '''
+    Test the wireless signal to a given ssid is strong enough
+    '''
+    print 'TEST SIGNAL'
+    passed=False
+    scan_command='iwlist wlan0 scan | grep -C 4 {}'.format(ssid)
+    print 'Wireless scanning SSID "{}"'.format(ssid),
+    sys.stdout.flush()
+
+    try:
+        found=False
+        for k in xrange(1, 5):
+            try:
+                scanned=os.popen(scan_command).read()
+                assert(ssid in scanned)
+                assert('Channel' in scanned)
+                assert('Quality' in scanned)
+                found=True
+                break
+            except:
+                time.sleep(1)
+                print '.',
+                sys.stdout.flush()
+
+        print
+        assert(found)
+
+        # Extract signal level details
+        # TODO: Refuse weak signals???
+        quality_signal=re.search('.*(Quality.*dBm).*', scanned)
+        print 'SSID={} - {}'.format(ssid, quality_signal.group().strip())
+        print 'PASSED'
+        passed=True
+    except:
+        print 'FAILED 1 - It looks like SSID "{}" is not in range, please get closer and try again'.format(ssid)
+
+    return passed
+
+
+def test_connection(ssid, passphrase):
+    '''
+    Test that we can associate with the given ssid network, manually.
+    '''
+    print 'TEST CONNECTION'
+    passed=False    
+
+    # First make sure that the supplicant is working
+    try:
+        status=os.popen('wpa_cli status 2>/dev/null').read()
+        assert(len(status))
+        os.system('pkill -f wpa_supplicant')
+    except:
+        pass
+
+    # The supplicant is not working, we put it to work
+    wpa_conf='/tmp/kano-test-wifi.conf'
+    with open(wpa_conf, 'w') as f:
+        f.write(test_wpa_conf % (ssid, passphrase))
+
+    os.system('wpa_supplicant -B -i wlan0 -c{}'.format(wpa_conf))
+    time.sleep(1)
+
+    # then fetch and display the progress for us
+    for i in xrange(1, 5):
+        status=os.popen('wpa_cli status 2>/dev/null').read()
+        if ('wpa_state=COMPLETED' in status):
+            print status
+            print 'PASSED'
+            passed=True
+            break
+        else:
+            time.sleep(1)
+
+    os.system('wpa_cli terminate')
+    if not passed:
+        print status
+        print 'FAILED: Could not associated to SSID "{}"'.format(ssid)
+
+    return passed
+
+
+
+if __name__ == '__main__':
+
+    args = docopt(__doc__)
+
+    if os.getuid() != 0:
+        print 'You must be root, please try to run with "sudo"'
+        sys.exit(0)
+
+    if args['test-all']:
+        success = test_device() and \
+                  test_signal(args['<ssid>']) and \
+                  test_connection(args['<ssid>'], args['--passphrase'] or '')
+
+    elif args['test-device']:
+        success = test_device()
+    elif args['test-signal']:
+        success = test_signal(args['<ssid>'])
+    elif args['test-connection']:
+        success = test_connection(args['<ssid>'], args['--passphrase'] or '')
+
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
A wireless diagnostic tool for Kano OS in 3 steps: device, signal and connection.
It connects to the WPA supplicant manually to collect the messages directly from the daemon.
That makes diagnosing the issue a lot clearer. Needs more polishing, sample session below.

@tombettany @Ealdwulf 

```
root@kano:/home/albert# ./kano-test-wifi
Usage:
  kano-test-wifi test-device
  kano-test-wifi test-signal <ssid>
  kano-test-wifi test-connection <ssid> [--passphrase=<secret>]
  kano-test-wifi test-all <ssid>  [--passphrase=<secret>]

root@kano:/home/albert# ./kano-test-wifi test-all blablabla --passphrase=wrongpassphrase
TEST DEVICE
Interface wlan0
        ifindex 3
        wdev 0x1
        addr xx:yy:xx:yy:xx:yy
        type managed
        wiphy 0

PASSED
TEST SIGNAL
Wireless scanning SSID "blablabla"
SSID=blablabla - Quality=51/70  Signal level=-59 dBm
PASSED
TEST CONNECTION
Successfully initialized wpa_supplicant
Selected interface 'wlan0'
OK
Selected interface 'wlan0'
bssid=xx:yy:xx:yy:xx:yy
freq=2437
ssid=blablabla
id=0
mode=station
pairwise_cipher=CCMP
group_cipher=CCMP
key_mgmt=WPA2-PSK
wpa_state=4WAY_HANDSHAKE
p2p_device_address=xx:yy:xx:yy:xx:yy
address=xx:yy:xx:yy:xx:yy
uuid=0bfcb7fd-0c7a-57d4-9876-c01b5c47e482

FAILED: Could not associated to SSID "blablabla"
```
